### PR TITLE
Add DriverScreen UI to Flutter app

### DIFF
--- a/mobile/lib/driver_screen.dart
+++ b/mobile/lib/driver_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+class DriverScreen extends StatefulWidget {
+  const DriverScreen({super.key});
+
+  @override
+  State<DriverScreen> createState() => _DriverScreenState();
+}
+
+class _DriverScreenState extends State<DriverScreen> {
+  final TextEditingController _timeController = TextEditingController();
+
+  Future<void> _pickTime() async {
+    final TimeOfDay? time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+    );
+    if (time != null) {
+      _timeController.text = time.format(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Driver Screen'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              decoration: const InputDecoration(labelText: 'Başlangıç konumu'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              decoration: const InputDecoration(labelText: 'Varış konumu'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _timeController,
+              decoration: const InputDecoration(labelText: 'Kalkış saati'),
+              readOnly: true,
+              onTap: _pickTime,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              decoration: const InputDecoration(labelText: 'Boş koltuk sayısı'),
+              keyboardType: TextInputType.number,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {},
+              child: const Text('Yolculuk Bildir'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'driver_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -30,7 +31,7 @@ class MyApp extends StatelessWidget {
         // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const DriverScreen(),
     );
   }
 }

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -11,20 +11,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('Driver screen UI elements appear', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that all required fields exist.
+    expect(find.text('Başlangıç konumu'), findsOneWidget);
+    expect(find.text('Varış konumu'), findsOneWidget);
+    expect(find.text('Kalkış saati'), findsOneWidget);
+    expect(find.text('Boş koltuk sayısı'), findsOneWidget);
+    expect(find.text('Yolculuk Bildir'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- implement `DriverScreen` with text fields and submit button
- show new screen as app home
- update widget test to check for new UI

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4b11bd5c833393e9b85ece4bf0ff