### PR TITLE
Add basic driver and passenger screens

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'screens/passenger_screen.dart';
+import 'screens/driver_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -30,6 +32,10 @@ class MyApp extends StatelessWidget {
         // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
+      routes: {
+        '/passenger': (context) => const PassengerScreen(),
+        '/driver': (context) => const DriverScreen(),
+      },
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }

--- a/mobile/lib/screens/driver_screen.dart
+++ b/mobile/lib/screens/driver_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class DriverScreen extends StatelessWidget {
+  const DriverScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        height: 250,
+        color: Colors.grey,
+        child: const Center(
+          child: Text('Buraya harita gelecek'),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/passenger_screen.dart
+++ b/mobile/lib/screens/passenger_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class PassengerScreen extends StatelessWidget {
+  const PassengerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        height: 250,
+        color: Colors.grey,
+        child: const Center(
+          child: Text('Buraya harita gelecek'),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create placeholder PassengerScreen & DriverScreen
- expose the screens via routes in MaterialApp

## Testing
- `dart format mobile/lib/main.dart mobile/lib/screens/passenger_screen.dart mobile/lib/screens/driver_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4c4353fc8333b51d707333984475