### PR TITLE
Add simple Driver and Passenger screens

### DIFF
--- a/mobile/lib/driver_screen.dart
+++ b/mobile/lib/driver_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class DriverScreen extends StatelessWidget {
+  const DriverScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Driver Screen')),
+      body: const Center(child: Text('Welcome, Driver!')),
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'driver_screen.dart';
+import 'passenger_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -13,23 +15,12 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
+      routes: {
+        '/driver': (context) => const DriverScreen(),
+        '/passenger': (context) => const PassengerScreen(),
+      },
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
@@ -108,6 +99,15 @@ class _MyHomePageState extends State<MyHomePage> {
             Text(
               '$_counter',
               style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () => Navigator.pushNamed(context, '/driver'),
+              child: const Text('Driver Screen'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pushNamed(context, '/passenger'),
+              child: const Text('Passenger Screen'),
             ),
           ],
         ),

--- a/mobile/lib/passenger_screen.dart
+++ b/mobile/lib/passenger_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class PassengerScreen extends StatelessWidget {
+  const PassengerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Passenger Screen')),
+      body: const Center(child: Text('Welcome, Passenger!')),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `DriverScreen` and `PassengerScreen`
- wire new screens into `MaterialApp` routes
- add navigation buttons from home screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4c452f488333814472ce650530cf