### PR TITLE
Add basic Express backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+*.log
+.env
+
+# Node server
+server/node_modules/
+server/package-lock.json

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.send('NoTaxi server is running');
+});
+
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- setup Node.js/Express backend in the `server` folder
- ignore Node artifacts
- implement server startup script that responds to `/`

## Testing
- `node server/src/index.js &` *(starts server)*
- `curl -s http://localhost:3000/`

------
https://chatgpt.com/codex/tasks/task_e_684f4dd466e08333a26471a2ab1576a3