### PR TITLE
Add ride request service

### DIFF
--- a/mobile/lib/services/ride_service.dart
+++ b/mobile/lib/services/ride_service.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+const String _baseUrl = 'http://localhost:3000';
+
+Future<void> sendRideRequest(RideRequest request) async {
+  final uri = Uri.parse('$_baseUrl/api/ride');
+  final response = await http.post(
+    uri,
+    headers: {'Content-Type': 'application/json'},
+    body: jsonEncode(request.toJson()),
+  );
+
+  if (response.statusCode >= 200 && response.statusCode < 300) {
+    print('Yolculuk gonderildi');
+  } else {
+    throw Exception('Ride request failed: ${response.statusCode}');
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add http dependency for Flutter project
- implement `sendRideRequest` function to post ride request JSON

## Testing
- `dart`/`flutter` commands not available in container

------
https://chatgpt.com/codex/tasks/task_e_684f4e88a5088333bbfe17f5cc15cbfd