### PR TITLE
Add ride request service and screens

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'ui/driver_screen.dart';
+import 'ui/passenger_screen.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -30,93 +33,38 @@ class MyApp extends StatelessWidget {
         // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const MyHomePage(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+class MyHomePage extends StatelessWidget {
+  const MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
+      appBar: AppBar(title: const Text('NoTaxi')),
       body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
         child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
           mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+          children: [
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const PassengerScreen()),
+              ),
+              child: const Text('Passenger'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const DriverScreen()),
+              ),
+              child: const Text('Driver'),
             ),
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/mobile/lib/models/ride_data.dart
+++ b/mobile/lib/models/ride_data.dart
@@ -1,0 +1,13 @@
+class RideData {
+  final String from;
+  final String to;
+  final bool isDriver;
+
+  RideData({required this.from, required this.to, required this.isDriver});
+
+  Map<String, dynamic> toJson() => {
+        'from': from,
+        'to': to,
+        'isDriver': isDriver,
+      };
+}

--- a/mobile/lib/services/ride_service.dart
+++ b/mobile/lib/services/ride_service.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/ride_data.dart';
+
+class RideService {
+  final http.Client client;
+  RideService({http.Client? client}) : client = client ?? http.Client();
+
+  Future<bool> sendRideRequest(RideData data) async {
+    final uri = Uri.parse('https://example.com/api/rides');
+    try {
+      final response = await client.post(
+        uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(data.toJson()),
+      );
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        return true;
+      } else {
+        return false;
+      }
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/mobile/lib/ui/driver_screen.dart
+++ b/mobile/lib/ui/driver_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../models/ride_data.dart';
+import '../services/ride_service.dart';
+
+class DriverScreen extends StatefulWidget {
+  const DriverScreen({super.key});
+
+  @override
+  State<DriverScreen> createState() => _DriverScreenState();
+}
+
+class _DriverScreenState extends State<DriverScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _fromController = TextEditingController();
+  final _toController = TextEditingController();
+  final _service = RideService();
+
+  @override
+  void dispose() {
+    _fromController.dispose();
+    _toController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    final data = RideData(
+      from: _fromController.text,
+      to: _toController.text,
+      isDriver: true,
+    );
+    bool success;
+    try {
+      success = await _service.sendRideRequest(data);
+    } catch (_) {
+      success = false;
+    }
+    if (!mounted) return;
+    final snackBar = SnackBar(
+      content: Text(
+        success
+            ? 'Yolculuk başarıyla bildirildi'
+            : 'Yolculuk bildirilemedi',
+      ),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(snackBar);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Driver')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _fromController,
+                decoration: const InputDecoration(labelText: 'From'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: _toController,
+                decoration: const InputDecoration(labelText: 'To'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _submit,
+                child: const Text('Send'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/ui/passenger_screen.dart
+++ b/mobile/lib/ui/passenger_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../models/ride_data.dart';
+import '../services/ride_service.dart';
+
+class PassengerScreen extends StatefulWidget {
+  const PassengerScreen({super.key});
+
+  @override
+  State<PassengerScreen> createState() => _PassengerScreenState();
+}
+
+class _PassengerScreenState extends State<PassengerScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _fromController = TextEditingController();
+  final _toController = TextEditingController();
+  final _service = RideService();
+
+  @override
+  void dispose() {
+    _fromController.dispose();
+    _toController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    final data = RideData(
+      from: _fromController.text,
+      to: _toController.text,
+      isDriver: false,
+    );
+    bool success;
+    try {
+      success = await _service.sendRideRequest(data);
+    } catch (_) {
+      success = false;
+    }
+    if (!mounted) return;
+    final snackBar = SnackBar(
+      content: Text(
+        success
+            ? 'Yolculuk başarıyla bildirildi'
+            : 'Yolculuk bildirilemedi',
+      ),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(snackBar);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Passenger')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _fromController,
+                decoration: const InputDecoration(labelText: 'From'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: _toController,
+                decoration: const InputDecoration(labelText: 'To'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _submit,
+                child: const Text('Send'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- implement `RideService.sendRideRequest`
- create `RideData` model
- add Passenger and Driver screens with simple ride forms
- hook new screens into `main.dart`
- update dependencies for HTTP client

## Testing
- `flutter format lib` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4f2872248333961f62516c9c5bef