### PR TITLE
Add PassengerScreen widget

### DIFF
--- a/mobile/lib/screens.dart
+++ b/mobile/lib/screens.dart
@@ -1,0 +1,1 @@
+export 'screens/passenger_screen.dart';

--- a/mobile/lib/screens/passenger_screen.dart
+++ b/mobile/lib/screens/passenger_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class PassengerScreen extends StatelessWidget {
+  const PassengerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Yolculuk Arama Ekranı'),
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {},
+          child: const Text('Ara'),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `PassengerScreen` widget
- export new screen via `screens.dart`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f535d8f988333a4f2120685a508ce