### PR TITLE
Add PassengerScreen widget test

### DIFF
--- a/mobile/lib/screens/passenger_screen.dart
+++ b/mobile/lib/screens/passenger_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class PassengerScreen extends StatelessWidget {
+  const PassengerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Passenger Screen'),
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {},
+          child: const Text('Request Ride'),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,30 +1,14 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:mobile/main.dart';
+import 'package:mobile/screens/passenger_screen.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Passenger screen shows title and button', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: PassengerScreen()));
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Passenger Screen'), findsOneWidget);
+    expect(find.text('Request Ride'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- implement a simple `PassengerScreen` widget
- create a widget test for `PassengerScreen`

## Testing
- `flutter test` *(fails: failed to retrieve Dart SDK)*

------
https://chatgpt.com/codex/tasks/task_e_684f5360406883339dc1503048aedd8c